### PR TITLE
test 2 and possible future change for amphtanks

### DIFF
--- a/common/units/equipment/modules/00_tank_modules.txt
+++ b/common/units/equipment/modules/00_tank_modules.txt
@@ -2044,12 +2044,12 @@ equipment_modules = {
 		forbid_equipment_type = flame
 
 		add_stats = {
-			build_cost_ic = 4
-			reliability = -0.15
+			build_cost_ic = 3
+			reliability = -0.10
 		}
 		
 		multiply_stats = {
-			build_cost_ic = 0.1
+		
 		}
 	}
 


### PR DESCRIPTION
Amphibious tanks doesn't get used as much because it's expensive.
Changes:
IC cost for module: 4 -> 3(same as hull flamethrower and external HMG
Reliability: -15% -> -10%(same as hull flamethrower and extra ammunition storage)
+10% extra production cost removed