### PR TITLE
lvl 5 fort for southern tile for El-Alamein

### DIFF
--- a/common/national_focus/uk.txt
+++ b/common/national_focus/uk.txt
@@ -2287,6 +2287,12 @@ focus_tree = {
 					province = 1071
 					instant_build = yes
 				}
+				set_building_level = {
+					type = bunker
+					level = 5
+					province = 10127
+					instant_build = yes
+				}
 				add_building_construction = {
 					type = anti_air_building
 					level = 2


### PR DESCRIPTION
Focus change for UK's "fortify Egypt". Adds a extra lvl 5 fort for the new southern tile